### PR TITLE
Fix reward accounting bug and add test

### DIFF
--- a/programs/bitsol/src/errors.rs
+++ b/programs/bitsol/src/errors.rs
@@ -36,4 +36,6 @@ pub enum BitSolError {
     RewardAlreadyClaimed,
     #[msg("Reward expired")]
     RewardExpired,
+    #[msg("Reward exceeds remaining supply")]
+    RewardExceedsSupply,
 }

--- a/programs/bitsol/src/instructions.rs
+++ b/programs/bitsol/src/instructions.rs
@@ -93,8 +93,8 @@ fn settle_and_mint_rewards<'info>(
     player.last_claim_slot = now;
     player.last_acc_bits_per_hash = gs.acc_bits_per_hash;
 
-    // split referral 25% to referrer
-    let referral_amount = pending * 25 / 100;
+    // split referral based on configured fee (per-mille)
+    let referral_amount = pending * gs.referral_fee as u64 / 1000;
     let player_amount = pending - referral_amount;
 
     // signer seeds
@@ -962,6 +962,11 @@ pub fn claim_global_random_reward(ctx: Context<ClaimGlobalRandomReward>) -> Resu
         .any(|r| r.generated_slot == reward.generated_slot);
     require!(!already_claimed, BitSolError::RewardAlreadyClaimed);
 
+    // Ensure reward does not exceed remaining supply
+    let minted_minus_burn = gs.cumulative_rewards.saturating_sub(gs.burned_tokens);
+    let remaining_supply = gs.total_supply.saturating_sub(minted_minus_burn);
+    require!(reward.amount <= remaining_supply, BitSolError::RewardExceedsSupply);
+
     // Mint reward to player
     let seeds = &[
         GLOBAL_STATE_SEED,
@@ -982,6 +987,12 @@ pub fn claim_global_random_reward(ctx: Context<ClaimGlobalRandomReward>) -> Resu
         ),
         reward.amount,
     )?;
+
+    // track supply and clear reward
+    gs.cumulative_rewards = gs
+        .cumulative_rewards
+        .saturating_add(reward.amount);
+    gs.global_random_reward = None;
 
     // Record claim
     let claimed = ClaimedGlobalReward {

--- a/tests/global_reward.test.ts
+++ b/tests/global_reward.test.ts
@@ -1,0 +1,89 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program, BN } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { Bitsol } from "../target/types/bitsol";
+import { setupTestProgram, setupTestPlayer } from "./test-helpers";
+
+describe("Bitsol - global random reward", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+  const program = anchor.workspace.Bitsol as Program<Bitsol>;
+
+  const HALVING_INTERVAL = 10;
+  const TOTAL_SUPPLY = new BN(1_000_000_000000);
+  const INITIAL_REWARD_RATE = new BN(100_000000);
+  const COOLDOWN_SLOTS = 1;
+
+  let tokenMint: PublicKey,
+      globalStateKey: PublicKey,
+      playerWallet: anchor.web3.Keypair,
+      playerKey: PublicKey,
+      playerTokenAccount: PublicKey;
+
+  beforeEach(async () => {
+    ({ tokenMint, globalStateKey } = await setupTestProgram(
+      provider,
+      program,
+      HALVING_INTERVAL,
+      TOTAL_SUPPLY,
+      INITIAL_REWARD_RATE,
+      COOLDOWN_SLOTS,
+    ));
+    ({ playerWallet, playerKey, playerTokenAccount } = await setupTestPlayer(
+      provider,
+      program,
+      tokenMint,
+      globalStateKey,
+    ));
+  });
+
+  it("allows claiming once and tracks supply", async () => {
+    const rewardAmount = new BN(5_000000); // 5 BITS
+    const expiry = new BN(5);
+
+    await program.methods
+      .generateGlobalRandomReward(rewardAmount, expiry)
+      .accountsStrict({
+        authority: provider.wallet.publicKey,
+        globalState: globalStateKey,
+        clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
+      })
+      .rpc();
+
+    const beforeGs = await program.account.globalState.fetch(globalStateKey);
+
+    await program.methods
+      .claimGlobalRandomReward()
+      .accountsStrict({
+        playerWallet: playerWallet.publicKey,
+        player: playerKey,
+        globalState: globalStateKey,
+        playerTokenAccount,
+        tokenMint,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
+      })
+      .signers([playerWallet])
+      .rpc();
+
+    const afterGs = await program.account.globalState.fetch(globalStateKey);
+    expect(afterGs.cumulativeRewards.sub(beforeGs.cumulativeRewards).toString()).toBe(rewardAmount.toString());
+
+    await expect(
+      program.methods
+        .claimGlobalRandomReward()
+        .accountsStrict({
+          playerWallet: playerWallet.publicKey,
+          player: playerKey,
+          globalState: globalStateKey,
+          playerTokenAccount,
+          tokenMint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
+        })
+        .signers([playerWallet])
+        .rpc()
+    ).rejects.toThrow(/NoPendingReward/);
+  });
+});


### PR DESCRIPTION
## Summary
- fix referral fee calculation to use configured value
- add supply checks in `claim_global_random_reward`
- track rewards in global state and clear the reward once claimed
- add regression test for global random rewards

## Testing
- `npm test` *(fails: jest not found)*